### PR TITLE
add filter on exports

### DIFF
--- a/www/modules/centreon-clapi/core/centreon
+++ b/www/modules/centreon-clapi/core/centreon
@@ -64,7 +64,8 @@ $shortopts .= "e"; /* Export all configuration */
 
 $longopts  = array(
     "select:",
-    "filter-type:"
+    "filter-type:",
+    "filter-ariane:"
 );
 
 $options = getopt($shortopts, $longopts);

--- a/www/modules/centreon-clapi/core/centreon
+++ b/www/modules/centreon-clapi/core/centreon
@@ -115,7 +115,7 @@ try {
  * Create Centreon API object
  */
 CentreonUtils::setUserName($options['u']);
-$api = new CentreonAPI((isset($options["u"]) ? $options["u"] : "") , (isset($options["p"]) ? $options["p"] : ""), (isset($options["a"]) ? $options["a"] : ""), $centreon_path, $options);
+$api = CentreonAPI::getInstance((isset($options["u"]) ? $options["u"] : "") , (isset($options["p"]) ? $options["p"] : ""), (isset($options["a"]) ? $options["a"] : ""), $centreon_path, $options);
 
 if (isset($options["h"])) {
     $api->printHelp();

--- a/www/modules/centreon-clapi/core/centreon
+++ b/www/modules/centreon-clapi/core/centreon
@@ -62,7 +62,12 @@ $shortopts .= "a:"; /* Action */
 $shortopts .= "i:"; /* Import Massive data */
 $shortopts .= "e"; /* Export all configuration */
 
-$options = getopt($shortopts);
+$longopts  = array(
+    "select:",
+    "filter-type:"
+);
+
+$options = getopt($shortopts, $longopts);
 if (isset($options['d'])) {
     $debug = 1;
 }

--- a/www/modules/centreon-clapi/core/class/centreonAPI.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonAPI.class.php
@@ -750,7 +750,9 @@ class CentreonAPI {
             $this->setReturnCode(1);
             $this->close();
         }
+        $exported->ariane_push($action, $filter_id, $filter_name);
         $this->objectTable[$action]->export($filter_id, $filter_name);
+        $exported->ariane_pop();
     }
     
     /**

--- a/www/modules/centreon-clapi/core/class/centreonAPI.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonAPI.class.php
@@ -724,11 +724,20 @@ class CentreonAPI {
         require_once "./class/centreonExported.class.php";
         $exported = CentreonExported::getInstance();
 
+        if (is_null($action)) {
+            return 0;
+        }
+        
         if (!isset($this->objectTable[$action])) {
             print "Unknown object : $action\n";
             $this->setReturnCode(1);
             $this->close();
         }
+            
+        if ($exported->is_exported($action, $filter_id, $filter_name)) {
+            return 0;
+        }
+        
         $exported->ariane_push($action, $filter_id, $filter_name);
         $this->objectTable[$action]->export($filter_id, $filter_name);
         $exported->ariane_pop();
@@ -746,6 +755,7 @@ class CentreonAPI {
         $this->initAllObjects();
         
         if (isset($this->action) && $this->variables != '') {
+            CentreonExported::getInstance()->set_filter(1);
             $this->export_filter($this->action, $this->objectTable[$this->action]->getObjectId($this->variables), $this->variables);
         } else {
             // header

--- a/www/modules/centreon-clapi/core/class/centreonAPI.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonAPI.class.php
@@ -754,9 +754,22 @@ class CentreonAPI {
         
         $this->initAllObjects();
         
-        if (isset($this->action) && $this->variables != '') {
+        if (isset($this->options['select'])) {
             CentreonExported::getInstance()->set_filter(1);
-            $this->export_filter($this->action, $this->objectTable[$this->action]->getObjectId($this->variables), $this->variables);
+            CentreonExported::getInstance()->set_options($this->options);
+            $selected = $this->options['select'];
+            if (!is_array($this->options['select'])) {
+                $selected = array($this->options['select']);
+            }
+            foreach ($selected as $select) {
+                $splits = explode(';', $select);
+                if (!isset($this->objectTable[$splits[0]])) {
+                    print "Unknown object : $splits[0]\n";
+                    $this->setReturnCode(1);
+                    $this->close();
+                }
+                $this->export_filter($splits[0], $this->objectTable[$splits[0]]->getObjectId($splits[1]), $splits[1]);
+            }
         } else {
             // header
             echo "{OBJECT_TYPE}{$this->delim}{COMMAND}{$this->delim}{PARAMETERS}\n";        

--- a/www/modules/centreon-clapi/core/class/centreonAPI.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonAPI.class.php
@@ -770,9 +770,9 @@ class CentreonAPI {
                     $this->close();
                 }
                 $this->export_filter($splits[0], $this->objectTable[$splits[0]]->getObjectId($splits[1]), $splits[1]);
-                # Don't want return \n
-                exit($this->return_code);
             }
+            # Don't want return \n
+            exit($this->return_code);
         } else {
             // header
             echo "{OBJECT_TYPE}{$this->delim}{COMMAND}{$this->delim}{PARAMETERS}\n";        

--- a/www/modules/centreon-clapi/core/class/centreonAPI.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonAPI.class.php
@@ -733,12 +733,13 @@ class CentreonAPI {
             $this->setReturnCode(1);
             $this->close();
         }
-            
+        
+        $exported->ariane_push($action, $filter_id, $filter_name);
         if ($exported->is_exported($action, $filter_id, $filter_name)) {
+            $exported->ariane_pop();
             return 0;
         }
         
-        $exported->ariane_push($action, $filter_id, $filter_name);
         $this->objectTable[$action]->export($filter_id, $filter_name);
         $exported->ariane_pop();
     }
@@ -769,6 +770,8 @@ class CentreonAPI {
                     $this->close();
                 }
                 $this->export_filter($splits[0], $this->objectTable[$splits[0]]->getObjectId($splits[1]), $splits[1]);
+                # Don't want return \n
+                exit($this->return_code);
             }
         } else {
             // header

--- a/www/modules/centreon-clapi/core/class/centreonCommand.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonCommand.class.php
@@ -182,9 +182,6 @@ class CentreonCommand extends CentreonObject {
 	{
         $filters = null;
         if (!is_null($filter_id)) {
-            if (CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name)) {
-                return 0;
-            }
             $filters = array('command_id' => $filter_id);
         }
         

--- a/www/modules/centreon-clapi/core/class/centreonCommand.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonCommand.class.php
@@ -85,6 +85,7 @@ class CentreonCommand extends CentreonObject {
         $elements = $this->object->getList($params, -1, 0, null, null, $filters);
         foreach ($elements as $tab) {
             $tab['command_line'] = CentreonUtils::convertSpecialPattern(html_entity_decode($tab['command_line']));
+            $tab['command_line'] = CentreonUtils::convertLineBreak($tab['command_line']);
             $tab['command_type'] = $this->typeConversion[$tab['command_type']];
             echo implode($this->delim, $tab) . "\n";
         }

--- a/www/modules/centreon-clapi/core/class/centreonCommand.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonCommand.class.php
@@ -171,6 +171,25 @@ class CentreonCommand extends CentreonObject {
         }
         return $id;
     }
+    
+    /**
+	 * Export data
+	 *
+	 * @param string $parameters
+	 * @return void
+	 */
+	public function export($filter_id=null, $filter_name=null)
+	{
+        $filters = null;
+        if (!is_null($filter_id)) {
+            if (CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name)) {
+                return 0;
+            }
+            $filters = array('command_id' => $filter_id);
+        }
+        
+        parent::export($filters);        
+    }
 
 }
 

--- a/www/modules/centreon-clapi/core/class/centreonContact.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonContact.class.php
@@ -386,9 +386,6 @@ class CentreonContact extends CentreonObject {
     public function export($filter_id=null, $filter_name=null) {
         $filters = array("contact_register" => $this->register);
         if (!is_null($filter_id)) {
-            if (CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name)) {
-                return 0;
-            }
             $filters['contact_id'] = $filter_id;
         }
         $elements = $this->object->getList("*", -1, 0, null, null, $filters, "AND");
@@ -406,16 +403,12 @@ class CentreonContact extends CentreonObject {
                         $parameter = self::HOST_NOTIF_TP;
                         $tmp_id = $value;
                         $value = $this->tpObject->getObjectName($value);
-                        if (!is_null($filter)) {
-                            $this->api->export_filter('TP', $tmp_id, $value);
-                        }
+                        $this->api->export_filter('TP', $tmp_id, $value);
                     } elseif ($parameter == "timeperiod_tp_id2") {
                         $parameter = self::SVC_NOTIF_TP;
                         $tmp_id = $value;
                         $value = $this->tpObject->getObjectName($value);
-                        if (!is_null($filter)) {
-                            $this->api->export_filter('TP', $tmp_id, $value);
-                        }
+                        $this->api->export_filter('TP', $tmp_id, $value);
                     } elseif ($parameter == "contact_lang") {
                         $parameter = "locale";
                     } elseif ($parameter == "contact_host_notification_options") {
@@ -427,9 +420,7 @@ class CentreonContact extends CentreonObject {
                         $tmp_id = $value;
                         $result = $this->object->getParameters($value, $this->object->getUniqueLabelField());
                         $value  = $result[$this->object->getUniqueLabelField()];
-                        if (!is_null($filter)) {
-                            $this->api->export_filter('CONTACTTPL', $tmp_id, $value);
-                        }
+                        $this->api->export_filter('CONTACTTPL', $tmp_id, $value);
                     }
                     $value = CentreonUtils::convertLineBreak($value);
                     echo $this->action . $this->delim . "setparam" . $this->delim . $element[$this->object->getUniqueLabelField()] . $this->delim . $parameter . $this->delim . $value . "\n";

--- a/www/modules/centreon-clapi/core/class/centreonContactGroup.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonContactGroup.class.php
@@ -206,9 +206,6 @@ class CentreonContactGroup extends CentreonObject {
     public function export($filter_id=null, $filter_name=null) {
         $filters = null;
         if (!is_null($filter)) {
-            if (CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name)) {
-                return 0;
-            }
             $filters['cg_id'] = $filter_id;
         }
         
@@ -216,9 +213,7 @@ class CentreonContactGroup extends CentreonObject {
         $obj = new Centreon_Object_Relation_Contact_Group_Contact();
         $elements = $obj->getMergedParameters(array("cg_name"), array("contact_name", "contact_id"), -1, 0, "cg_name");
         foreach ($elements as $element) {
-            if (!is_null($filter)) {
-                $this->api->export_filter('CONTACT', $element['contact_id'], $element['contact_name']);
-            }
+            $this->api->export_filter('CONTACT', $element['contact_id'], $element['contact_name']);
             echo $this->action . $this->delim . "addcontact" . $this->delim . $element['cg_name'] . $this->delim . $element['contact_name'] . "\n";
         }
     }

--- a/www/modules/centreon-clapi/core/class/centreonContactGroup.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonContactGroup.class.php
@@ -204,11 +204,22 @@ class CentreonContactGroup extends CentreonObject {
      *
      * @return void
      */
-    public function export() {
-        parent::export();
+    public function export($filter_id=null, $filter_name=null) {
+        $filters = null;
+        if (!is_null($filter)) {
+            if (CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name)) {
+                return 0;
+            }
+            $filters['cg_id'] = $filter_id;
+        }
+        
+        parent::export($filters);
         $obj = new Centreon_Object_Relation_Contact_Group_Contact();
-        $elements = $obj->getMergedParameters(array("cg_name"), array("contact_name"), -1, 0, "cg_name");
+        $elements = $obj->getMergedParameters(array("cg_name"), array("contact_name", "contact_id"), -1, 0, "cg_name");
         foreach ($elements as $element) {
+            if (!is_null($filter)) {
+                $this->api->export_filter('CONTACT', $element['contact_id'], $element['contact_name']);
+            }
             echo $this->action . $this->delim . "addcontact" . $this->delim . $element['cg_name'] . $this->delim . $element['contact_name'] . "\n";
         }
     }

--- a/www/modules/centreon-clapi/core/class/centreonExported.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonExported.class.php
@@ -40,6 +40,7 @@ class CentreonExported {
   private $ariane = array();
   private $filter = 0;
   private $filter_type = null;
+  private $filter_ariane = null;
  
   /**
    * @var Singleton
@@ -56,7 +57,7 @@ class CentreonExported {
     }
  
     public function ariane_push($object, $id, $name) {
-        array_push($this->ariane, $object . ':' . $id . ':' . $name);
+        array_push($this->ariane, $object . ':' . $name . ':' . $id);
     }
     public function ariane_pop() {
         array_pop($this->ariane);
@@ -72,6 +73,27 @@ class CentreonExported {
                 $this->filter_type = array($options['filter-type']);
             }
         }
+        
+        if (isset($options['filter-ariane'])) {
+            $this->filter_ariane = $options['filter-ariane'];
+            if (!is_array($options['filter-ariane'])) {
+                $this->filter_ariane = array($options['filter-ariane']);
+            }
+        }
+    }
+    
+    private function check_ariane($object, $id, $name) {
+        if (!is_null($this->filter_ariane)) {
+            $ariane = join('#', $this->ariane);
+            foreach ($this->filter_ariane as $filter) {
+                if (preg_match('/' . $filter . '/', $ariane)) {
+                    return 0;
+                }
+            }
+            return 1;
+        }
+        
+        return 0;
     }
  
     private function check_filter($object, $id, $name) {
@@ -81,9 +103,10 @@ class CentreonExported {
                     return 0;
                 }
             }
+            return 1;
         }
         
-        return 1;
+        return 0;
     }
  
     public function is_exported($object, $id, $name) {
@@ -97,6 +120,9 @@ class CentreonExported {
         
         # check if there is some filters
         if ($this->check_filter($object, $id, $name)) {
+            return 1;
+        }
+        if ($this->check_ariane($object, $id, $name)) {
             return 1;
         }
        

--- a/www/modules/centreon-clapi/core/class/centreonExported.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonExported.class.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Copyright 2005-2015 CENTREON
+ * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * GPL Licence 2.0.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation ; either version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ * Linking this program statically or dynamically with other modules is making a
+ * combined work based on this program. Thus, the terms and conditions of the GNU
+ * General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this program give CENTREON
+ * permission to link this program with independent modules to produce an executable,
+ * regardless of the license terms of these independent modules, and to copy and
+ * distribute the resulting executable under terms of CENTREON choice, provided that
+ * CENTREON also meet, for each linked independent module, the terms  and conditions
+ * of the license of that module. An independent module is a module which is not
+ * derived from this program. If you modify this program, you may extend this
+ * exception to your version of the program, but you are not obliged to do so. If you
+ * do not wish to do so, delete this exception statement from your version.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+class CentreonExported {
+
+  private $exported = array();
+ 
+  /**
+   * @var Singleton
+   * @access private
+   * @static
+   */
+   private static $_instance = null;
+ 
+   /**    *
+    * @param void
+    * @return void
+    */
+    private function __construct() {  
+    }
+ 
+    public function is_exported($object, $id, $name) {
+        if (isset($this->exported[$object][$id])) {
+            return 1;
+        }
+        
+        if (!is_array($this->exported[$object])) {
+            $this->exported[$object] = array();
+        }
+        $this->exported[$object][$id] = 1;
+        return 0;
+    }
+ 
+   /**
+    *
+    * @param void
+    * @return CentreonExported
+    */
+    public static function getInstance() {
+        if(is_null(self::$_instance)) {
+            self::$_instance = new CentreonExported();  
+        }
+ 
+        return self::$_instance;
+    }
+}
+ 
+?>

--- a/www/modules/centreon-clapi/core/class/centreonExported.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonExported.class.php
@@ -38,6 +38,7 @@ class CentreonExported {
 
   private $exported = array();
   private $ariane = array();
+  private $filter = 0;
  
   /**
    * @var Singleton
@@ -60,7 +61,15 @@ class CentreonExported {
         array_pop($this->ariane);
     }
  
+    public function set_filter($value=1) {
+        $this->filter = $value;
+    }
+ 
     public function is_exported($object, $id, $name) {
+        if ($this->filter == 0) {
+            return 1;
+        }
+    
         if (isset($this->exported[$object][$id])) {
             return 1;
         }

--- a/www/modules/centreon-clapi/core/class/centreonExported.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonExported.class.php
@@ -37,6 +37,7 @@
 class CentreonExported {
 
   private $exported = array();
+  private $ariane = array();
  
   /**
    * @var Singleton
@@ -50,6 +51,13 @@ class CentreonExported {
     * @return void
     */
     private function __construct() {  
+    }
+ 
+    public function ariane_push($object, $id, $name) {
+        array_push($this->ariane, $object . ':' . $id . ':' . $name);
+    }
+    public function ariane_pop() {
+        array_pop($this->ariane);
     }
  
     public function is_exported($object, $id, $name) {

--- a/www/modules/centreon-clapi/core/class/centreonExported.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonExported.class.php
@@ -39,6 +39,7 @@ class CentreonExported {
   private $exported = array();
   private $ariane = array();
   private $filter = 0;
+  private $filter_type = null;
  
   /**
    * @var Singleton
@@ -64,6 +65,26 @@ class CentreonExported {
     public function set_filter($value=1) {
         $this->filter = $value;
     }
+    public function set_options($options) {
+        if (isset($options['filter-type'])) {
+            $this->filter_type = $options['filter-type'];
+            if (!is_array($options['filter-type'])) {
+                $this->filter_type = array($options['filter-type']);
+            }
+        }
+    }
+ 
+    private function check_filter($object, $id, $name) {
+        if (!is_null($this->filter_type)) {
+            foreach ($this->filter_type as $filter) {
+                if (preg_match('/' . $filter . '/', $object)) {
+                    return 0;
+                }
+            }
+        }
+        
+        return 1;
+    }
  
     public function is_exported($object, $id, $name) {
         if ($this->filter == 0) {
@@ -74,6 +95,11 @@ class CentreonExported {
             return 1;
         }
         
+        # check if there is some filters
+        if ($this->check_filter($object, $id, $name)) {
+            return 1;
+        }
+       
         if (!is_array($this->exported[$object])) {
             $this->exported[$object] = array();
         }

--- a/www/modules/centreon-clapi/core/class/centreonHost.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonHost.class.php
@@ -769,9 +769,6 @@ class CentreonHost extends CentreonObject {
     public function export($filter_id=null, $filter_name=null) {
         $filters = array("host_register" => $this->register);
         if (!is_null($filter_id)) {
-            if (($return_value = CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name))) {
-                return $return_value;
-            }
             $filters['host_id'] = $filter_id;
         }
     
@@ -850,9 +847,7 @@ class CentreonHost extends CentreonObject {
         }
         $elements = $cgRel->getMergedParameters(array("cg_name", "cg_id"), array($this->object->getUniqueLabelField()), -1, 0, null, null, $filters_cgRel, "AND");
         foreach ($elements as $element) {
-            if (!is_null($filter_id)) {
-                $this->api->export_filter('CG', $element['cg_id'], $element['cg_name']);
-            }
+            $this->api->export_filter('CG', $element['cg_id'], $element['cg_name']);
             echo $this->action . $this->delim . "addcontactgroup" . $this->delim . $element[$this->object->getUniqueLabelField()] . $this->delim . $element['cg_name'] . "\n";
         }
         
@@ -863,9 +858,7 @@ class CentreonHost extends CentreonObject {
         }
         $elements = $contactRel->getMergedParameters(array("contact_name", "contact_id"), array($this->object->getUniqueLabelField()), -1, 0, null, null, $filters_contactRel, "AND");
         foreach ($elements as $element) {
-            if (!is_null($filter_id)) {
-                $this->api->export_filter('CONTACT', $element['contact_id'], $element['contact_name']);
-            }
+            $this->api->export_filter('CONTACT', $element['contact_id'], $element['contact_name']);
             echo $this->action . $this->delim . "addcontact" . $this->delim . $element[$this->object->getUniqueLabelField()] . $this->delim . $element['contact_name'] . "\n";
         }
         
@@ -876,9 +869,7 @@ class CentreonHost extends CentreonObject {
         }
         $elements = $htplRel->getMergedParameters(array("host_name as host"), array("host_name as template", "host_id as tpl_id"), -1, 0, "host,`order`", "ASC", $filters_htplRel, "AND");
         foreach ($elements as $element) {
-            if (!is_null($filter_id)) {
-                $this->api->export_filter('HTPL', $element['tpl_id'], $element['template']);
-            }
+            $this->api->export_filter('HTPL', $element['tpl_id'], $element['template']);
             echo $this->action . $this->delim . "addtemplate" . $this->delim . $element['host'] . $this->delim . $element['template'] . "\n";
         }
         

--- a/www/modules/centreon-clapi/core/class/centreonHost.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonHost.class.php
@@ -41,6 +41,7 @@ require_once "centreonUtils.class.php";
 require_once "centreonTimePeriod.class.php";
 require_once "centreonACL.class.php";
 require_once "centreonCommand.class.php";
+require_once "centreonExported.class.php";
 require_once "Centreon/Object/Instance/Instance.php";
 require_once "Centreon/Object/Command/Command.php";
 require_once "Centreon/Object/Timeperiod/Timeperiod.php";
@@ -764,8 +765,16 @@ class CentreonHost extends CentreonObject {
      *
      * @return void
      */
-    public function export() {
-        $elements = $this->object->getList("*", -1, 0, null, null, array("host_register" => $this->register), "AND");
+    public function export($filter_id=null, $filter_name=null) {
+        $filters = array("host_register" => $this->register);
+        if (!is_null($filter_id)) {
+            if (($return_value = CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name))) {
+                return $return_value;
+            }
+            $filters['host_id'] = $filter_id;
+        }
+    
+        $elements = $this->object->getList("*", -1, 0, null, null, $filters, "AND");
         $extendedObj = new Centreon_Object_Host_Extended();
         $commandObj = new Centreon_Object_Command();
         $tpObj = new Centreon_Object_Timeperiod();
@@ -795,15 +804,22 @@ class CentreonHost extends CentreonObject {
             echo $addStr;
             foreach ($element as $parameter => $value) {
                 if (!in_array($parameter, $this->exportExcludedParams) && !is_null($value) && $value != "") {
+                    $action_tmp = null;
                     if ($parameter == "timeperiod_tp_id" || $parameter == "timeperiod_tp_id2") {
+                        $action_tmp = 'TP';
                         $tmpObj = $tpObj;
                     } elseif ($parameter == "command_command_id" || $parameter == "command_command_id2") {
+                        $action_tmp = 'CMD';
                         $tmpObj = $commandObj;
                     }
                     if (isset($tmpObj)) {
                         $tmp = $tmpObj->getParameters($value, $tmpObj->getUniqueLabelField());
                         if (isset($tmp) && isset($tmp[$tmpObj->getUniqueLabelField()])) {
+                            $tmp_id = $value;
                             $value = $tmp[$tmpObj->getUniqueLabelField()];
+                            if (!is_null($filter_id) && !is_null($action_tmp)) {
+                                $this->api->export_filter($action_tmp, $tmp_id, $value);
+                            }
                         }
                         unset($tmpObj);
                     }
@@ -827,19 +843,67 @@ class CentreonHost extends CentreonObject {
             }
         }
         $cgRel = new Centreon_Object_Relation_Contact_Group_Host();
-        $elements = $cgRel->getMergedParameters(array("cg_name"), array($this->object->getUniqueLabelField()), -1, 0, null, null, array("host_register" => $this->register), "AND");
+        $filters_cgRel = array("host_register" => $this->register);
+        if (!is_null($filter_id)) {
+            $filters_cgRel['host_id'] = $filter_id;
+        }
+        $elements = $cgRel->getMergedParameters(array("cg_name", "cg_id"), array($this->object->getUniqueLabelField()), -1, 0, null, null, $filters_cgRel, "AND");
         foreach ($elements as $element) {
+            if (!is_null($filter_id)) {
+                $this->api->export_filter('CG', $element['cg_id'], $element['cg_name']);
+            }
             echo $this->action . $this->delim . "addcontactgroup" . $this->delim . $element[$this->object->getUniqueLabelField()] . $this->delim . $element['cg_name'] . "\n";
         }
+        
         $contactRel = new Centreon_Object_Relation_Contact_Host();
-        $elements = $contactRel->getMergedParameters(array("contact_name"), array($this->object->getUniqueLabelField()), -1, 0, null, null, array("host_register" => $this->register), "AND");
+        $filters_contactRel = array("host_register" => $this->register);
+        if (!is_null($filter_id)) {
+            $filters_contactRel['host_id'] = $filter_id;
+        }
+        $elements = $contactRel->getMergedParameters(array("contact_name", "contact_id"), array($this->object->getUniqueLabelField()), -1, 0, null, null, $filters_contactRel, "AND");
         foreach ($elements as $element) {
+            if (!is_null($filter_id)) {
+                $this->api->export_filter('CONTACT', $element['contact_id'], $element['contact_name']);
+            }
             echo $this->action . $this->delim . "addcontact" . $this->delim . $element[$this->object->getUniqueLabelField()] . $this->delim . $element['contact_name'] . "\n";
         }
+        
         $htplRel = new Centreon_Object_Relation_Host_Template_Host();
-        $elements = $htplRel->getMergedParameters(array("host_name as host"), array("host_name as template"), -1, 0, "host,`order`", "ASC", array("h.host_register" => $this->register), "AND");
+        $filters_htplRel = array("h.host_register" => $this->register);
+        if (!is_null($filter_id)) {
+            $filters_htplRel['h.host_id'] = $filter_id;
+        }
+        $elements = $htplRel->getMergedParameters(array("host_name as host"), array("host_name as template", "host_id as tpl_id"), -1, 0, "host,`order`", "ASC", $filters_htplRel, "AND");
         foreach ($elements as $element) {
+            if (!is_null($filter_id)) {
+                $this->api->export_filter('HTPL', $element['tpl_id'], $element['template']);
+            }
             echo $this->action . $this->delim . "addtemplate" . $this->delim . $element['host'] . $this->delim . $element['template'] . "\n";
+        }
+        
+        // Filter only
+        if (!is_null($filter_id)) {            
+            # service templates linked
+            $hostRel = new Centreon_Object_Relation_Host_Service();
+            $helements = $hostRel->getMergedParameters(array("host_name"), array('service_description', 'service_id'), -1, 0, null, null, array("service_register" => 0, "host_id" => $filter_id), "AND");
+            foreach ($helements as $helement) {
+                $this->api->export_filter('STPL', $helement['service_id'], $helement['service_description']);
+            }
+            
+            # service linked
+            $hostRel = new Centreon_Object_Relation_Host_Service();
+            $helements = $hostRel->getMergedParameters(array("host_name"), array('service_description', 'service_id'), -1, 0, null, null, array("service_register" => 1, "host_id" => $filter_id), "AND");
+            foreach ($helements as $helement) {
+                $this->api->export_filter('SERVICE', $helement['service_id'], $helement['service_description']);
+            }
+            
+            # service hg linked and hostgroups
+            $hostRel = new Centreon_Object_Relation_Host_Group_Host();
+            $helements = $hostRel->getMergedParameters(array("hg_name", "hg_id"), array('*'), -1, 0, null, null, array("host_id" => $filter_id), "AND");
+            foreach ($helements as $helement) {
+                $this->api->export_filter('HG', $helement['hg_id'], $helement['hg_name']);
+                $this->api->export_filter('HGSERVICE', $helement['hg_id'], $helement['hg_name']);
+            }            
         }
     }
 

--- a/www/modules/centreon-clapi/core/class/centreonHostGroup.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonHostGroup.class.php
@@ -231,15 +231,26 @@ class CentreonHostGroup extends CentreonObject
      *
      * @return void
      */
-    public function export()
+    public function export($filter_id=null, $filter_name=null)
     {
-        parent::export();
+        $filters = null;
+        if (!is_null($filter_id)) {
+            if (CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name)) {
+                return 0;
+            }
+            $filters = array('hg_id' => $filter_id);
+        }
+        
+        parent::export($filters);
         $relObj = new Centreon_Object_Relation_Host_Group_Host();
         $hostObj = new Centreon_Object_Host();
         $hgFieldName = $this->object->getUniqueLabelField();
         $hFieldName = $hostObj->getUniqueLabelField();
-        $elements = $relObj->getMergedParameters(array($hgFieldName), array($hFieldName), -1, 0, $hgFieldName, null);
+        $elements = $relObj->getMergedParameters(array($hgFieldName), array($hFieldName, 'host_id'), -1, 0, $hgFieldName, null);
         foreach ($elements as $element) {
+            if (!is_null($filter_id)) {
+                $this->api->export_filter('HOST', $element['host_id'], $element[$hFieldName]);
+            }
             echo $this->action.$this->delim."addhost".$this->delim.$element[$hgFieldName].$this->delim.$element[$hFieldName]."\n";
         }
     }

--- a/www/modules/centreon-clapi/core/class/centreonHostGroup.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonHostGroup.class.php
@@ -239,9 +239,6 @@ class CentreonHostGroup extends CentreonObject
     {
         $filters = null;
         if (!is_null($filter_id)) {
-            if (CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name)) {
-                return 0;
-            }
             $filters = array('hg_id' => $filter_id);
         }
         
@@ -252,9 +249,7 @@ class CentreonHostGroup extends CentreonObject
         $hFieldName = $hostObj->getUniqueLabelField();
         $elements = $relObj->getMergedParameters(array($hgFieldName), array($hFieldName, 'host_id'), -1, 0, $hgFieldName, null);
         foreach ($elements as $element) {
-            if (!is_null($filter_id)) {
-                $this->api->export_filter('HOST', $element['host_id'], $element[$hFieldName]);
-            }
+            $this->api->export_filter('HOST', $element['host_id'], $element[$hFieldName]);
             echo $this->action.$this->delim."addhost".$this->delim.$element[$hgFieldName].$this->delim.$element[$hFieldName]."\n";
         }
     }

--- a/www/modules/centreon-clapi/core/class/centreonHostGroupService.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonHostGroupService.class.php
@@ -644,10 +644,17 @@ class CentreonHostGroupService extends CentreonObject
      *
      * @return void
      */
-    public function export()
+    public function export($filter_id=null, $filter_name=null)
     {
+        $filters = array("service_register" => $this->register);
+        if (!is_null($filter_id)) {
+            if (($return_value = CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name))) {
+                return $return_value;
+            }
+            $filters['hg_id'] = $filter_id;
+        }
         $hostRel = new Centreon_Object_Relation_Host_Group_Service();
-        $elements = $hostRel->getMergedParameters(array("hg_name"), array('*'), -1, 0, null, null, array("service_register" => $this->register), "AND");
+        $elements = $hostRel->getMergedParameters(array("hg_name"), array('*'), -1, 0, null, null, $filters, "AND");
         $extendedObj = new Centreon_Object_Service_Extended();
         $commandObj = new Centreon_Object_Command();
         $tpObj = new Centreon_Object_Timeperiod();
@@ -657,9 +664,13 @@ class CentreonHostGroupService extends CentreonObject
             foreach ($this->insertParams as $param) {
                 $addStr .= $this->delim;
                 if ($param == "service_template_model_stm_id") {
+                    $tmp_id = $element[$param];
                     $tmp = $this->object->getParameters($element[$param], 'service_description');
                     if (isset($tmp) && isset($tmp['service_description']) && $tmp['service_description']) {
                         $element[$param] = $tmp['service_description'];
+                        if (!is_null($filter_id)) {
+                            $this->api->export_filter('STPL', $tmp_id, $tmp['service_description']);
+                        }
                     }
                     if (!$element[$param]) {
                         $element[$param] = "";
@@ -671,15 +682,22 @@ class CentreonHostGroupService extends CentreonObject
             echo $addStr;
             foreach ($element as $parameter => $value) {
                 if (!in_array($parameter, $this->exportExcludedParams) && !is_null($value) && $value != "") {
+                    $action_tmp = null;
                     if ($parameter == "timeperiod_tp_id" || $parameter == "timeperiod_tp_id2") {
+                        $action_tmp = 'TP';
                         $tmpObj = $tpObj;
                     } elseif ($parameter == "command_command_id" || $parameter == "command_command_id2") {
+                        $action_tmp = 'CMD';
                         $tmpObj = $commandObj;
                     }
                     if (isset($tmpObj)) {
                         $tmp = $tmpObj->getParameters($value, $tmpObj->getUniqueLabelField());
                         if (isset($tmp) && isset($tmp[$tmpObj->getUniqueLabelField()])) {
+                            $tmp_id = $value;
                             $value = $tmp[$tmpObj->getUniqueLabelField()];
+                            if (!is_null($filter_id) && !is_null($action_tmp)) {
+                                $this->api->export_filter($action_tmp, $tmp_id, $value);
+                            }
                         }
                         unset($tmpObj);
                     }
@@ -700,13 +718,19 @@ class CentreonHostGroupService extends CentreonObject
                 echo $this->action.$this->delim."setmacro".$this->delim.$element['hg_name'].$this->delim.$element['service_description'].$this->delim.$this->stripMacro($macro['svc_macro_name']).$this->delim.$macro['svc_macro_value']."\n";
             }
             $cgRel = new Centreon_Object_Relation_Contact_Group_Service();
-            $cgelements = $cgRel->getMergedParameters(array("cg_name"), array('service_description'), -1, 0, null, null, array("service_register" => $this->register, "service_id" => $element['service_id']), "AND");
+            $cgelements = $cgRel->getMergedParameters(array("cg_name", "cg_id"), array('service_description'), -1, 0, null, null, array("service_register" => $this->register, "service_id" => $element['service_id']), "AND");
             foreach ($cgelements as $cgelement) {
+                if (!is_null($filter_id)) {
+                    $this->api->export_filter('CG', $element['cg_id'], $element['cg_name']);
+                }
                 echo $this->action.$this->delim."addcontactgroup".$this->delim.$element['hg_name'].$this->delim.$cgelement['service_description'].$this->delim.$cgelement['cg_name']."\n";
             }
             $contactRel = new Centreon_Object_Relation_Contact_Service();
-            $celements = $contactRel->getMergedParameters(array("contact_name"), array('service_description'), -1, 0, null, null, array("service_register" => $this->register, "service_id" => $element['service_id']), "AND");
+            $celements = $contactRel->getMergedParameters(array("contact_name", "contact_id"), array('service_description'), -1, 0, null, null, array("service_register" => $this->register, "service_id" => $element['service_id']), "AND");
             foreach ($celements as $celement) {
+                if (!is_null($filter_id)) {
+                    $this->api->export_filter('CONTACT', $element['contact_id'], $element['contact_name']);
+                }
                 echo $this->action.$this->delim."addcontact".$this->delim.$element['hg_name'].$this->delim.$celement['service_description'].$this->delim.$celement['contact_name']."\n";
             }
         }

--- a/www/modules/centreon-clapi/core/class/centreonHostGroupService.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonHostGroupService.class.php
@@ -653,9 +653,6 @@ class CentreonHostGroupService extends CentreonObject
     {
         $filters = array("service_register" => $this->register);
         if (!is_null($filter_id)) {
-            if (($return_value = CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name))) {
-                return $return_value;
-            }
             $filters['hg_id'] = $filter_id;
         }
         $hostRel = new Centreon_Object_Relation_Host_Group_Service();
@@ -673,9 +670,7 @@ class CentreonHostGroupService extends CentreonObject
                     $tmp = $this->object->getParameters($element[$param], 'service_description');
                     if (isset($tmp) && isset($tmp['service_description']) && $tmp['service_description']) {
                         $element[$param] = $tmp['service_description'];
-                        if (!is_null($filter_id)) {
-                            $this->api->export_filter('STPL', $tmp_id, $tmp['service_description']);
-                        }
+                        $this->api->export_filter('STPL', $tmp_id, $tmp['service_description']);
                     }
                     if (!$element[$param]) {
                         $element[$param] = "";
@@ -700,9 +695,7 @@ class CentreonHostGroupService extends CentreonObject
                         if (isset($tmp) && isset($tmp[$tmpObj->getUniqueLabelField()])) {
                             $tmp_id = $value;
                             $value = $tmp[$tmpObj->getUniqueLabelField()];
-                            if (!is_null($filter_id) && !is_null($action_tmp)) {
-                                $this->api->export_filter($action_tmp, $tmp_id, $value);
-                            }
+                            $this->api->export_filter($action_tmp, $tmp_id, $value);
                         }
                         unset($tmpObj);
                     }
@@ -725,17 +718,13 @@ class CentreonHostGroupService extends CentreonObject
             $cgRel = new Centreon_Object_Relation_Contact_Group_Service();
             $cgelements = $cgRel->getMergedParameters(array("cg_name", "cg_id"), array('service_description'), -1, 0, null, null, array("service_register" => $this->register, "service_id" => $element['service_id']), "AND");
             foreach ($cgelements as $cgelement) {
-                if (!is_null($filter_id)) {
-                    $this->api->export_filter('CG', $element['cg_id'], $element['cg_name']);
-                }
+                $this->api->export_filter('CG', $element['cg_id'], $element['cg_name']);
                 echo $this->action.$this->delim."addcontactgroup".$this->delim.$element['hg_name'].$this->delim.$cgelement['service_description'].$this->delim.$cgelement['cg_name']."\n";
             }
             $contactRel = new Centreon_Object_Relation_Contact_Service();
             $celements = $contactRel->getMergedParameters(array("contact_name", "contact_id"), array('service_description'), -1, 0, null, null, array("service_register" => $this->register, "service_id" => $element['service_id']), "AND");
             foreach ($celements as $celement) {
-                if (!is_null($filter_id)) {
-                    $this->api->export_filter('CONTACT', $element['contact_id'], $element['contact_name']);
-                }
+                $this->api->export_filter('CONTACT', $element['contact_id'], $element['contact_name']);
                 echo $this->action.$this->delim."addcontact".$this->delim.$element['hg_name'].$this->delim.$celement['service_description'].$this->delim.$celement['contact_name']."\n";
             }
         }

--- a/www/modules/centreon-clapi/core/class/centreonObject.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonObject.class.php
@@ -34,6 +34,8 @@
  * SVN : $URL$
  * SVN : $Id$
  */
+ 
+require_once "centreonAPI.class.php";
 require_once "Centreon/Db/Manager/Manager.php";
 require_once "Centreon/Object/Contact/Contact.php";
 require_once "centreonClapiException.class.php";
@@ -50,6 +52,8 @@ abstract class CentreonObject
     const UNKNOWNPARAMETER = "Unknown parameter";
     const OBJECTALREADYLINKED = "Objects already linked";
     const OBJECTNOTLINKED = "Objects are not linked";
+    private $centreon_api = null;
+
 
     /**
      * Db adapter
@@ -122,6 +126,7 @@ abstract class CentreonObject
         $this->exportExcludedParams = array();
         $this->action = "";
         $this->delim = ";";
+        $this->api = CentreonAPI::getInstance();
     }
 
     /**
@@ -337,25 +342,25 @@ abstract class CentreonObject
 	 * @param string $parameters
 	 * @return void
 	 */
-	public function export()
+	public function export($filters=null)
 	{
-            $elements = $this->object->getList("*", -1, 0);
-            foreach ($elements as $element) {
-                $addStr = $this->action.$this->delim."ADD";
-                foreach ($this->insertParams as $param) {
-                    $addStr .= $this->delim.$element[$param];
-                }
-                $addStr .= "\n";
-                echo $addStr;
-                foreach ($element as $parameter => $value) {
-                    if (!in_array($parameter, $this->exportExcludedParams)) {
-                        if (!is_null($value) && $value != "") {
-                            $value = CentreonUtils::convertLineBreak($value);
-                            echo $this->action.$this->delim."setparam".$this->delim.$element[$this->object->getUniqueLabelField()].$this->delim.$parameter.$this->delim.$value."\n";
-                        }
+        $elements = $this->object->getList("*", -1, 0, null, null, $filters, "AND");
+        foreach ($elements as $element) {
+            $addStr = $this->action.$this->delim."ADD";
+            foreach ($this->insertParams as $param) {
+                $addStr .= $this->delim.$element[$param];
+            }
+            $addStr .= "\n";
+            echo $addStr;
+            foreach ($element as $parameter => $value) {
+                if (!in_array($parameter, $this->exportExcludedParams)) {
+                    if (!is_null($value) && $value != "") {
+                        $value = CentreonUtils::convertLineBreak($value);
+                        echo $this->action.$this->delim."setparam".$this->delim.$element[$this->object->getUniqueLabelField()].$this->delim.$parameter.$this->delim.$value."\n";
                     }
                 }
             }
+        }
     }
 
     /**

--- a/www/modules/centreon-clapi/core/class/centreonService.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonService.class.php
@@ -806,9 +806,6 @@ class CentreonService extends CentreonObject {
     public function export($filter_id=null, $filter_name=null) {
         $filters = array("service_register" => $this->register);
         if (!is_null($filter_id)) {
-            if (CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name)) {
-                return 0;
-            }
             $filters['service_id'] = $filter_id;
         }
     
@@ -827,9 +824,7 @@ class CentreonService extends CentreonObject {
                     $tmp = $this->object->getParameters($element[$param], 'service_description');
                     if (isset($tmp) && isset($tmp['service_description']) && $tmp['service_description']) {
                         $element[$param] = $tmp['service_description'];
-                        if (!is_null($filter_id)) {
-                            $this->api->export_filter('STPL', $tmp_id, $tmp['service_description']);
-                        }
+                        $this->api->export_filter('STPL', $tmp_id, $tmp['service_description']);
                     }
                     if (!$element[$param]) {
                         $element[$param] = "";
@@ -854,17 +849,13 @@ class CentreonService extends CentreonObject {
                         if (isset($tmp) && isset($tmp[$tmpObj->getUniqueLabelField()])) {
                             $tmp_id = $value;
                             $value = $tmp[$tmpObj->getUniqueLabelField()];
-                            if (!is_null($filter_id) && !is_null($action_tmp)) {
-                                $this->api->export_filter($action_tmp, $tmp_id, $value);
-                            }
+                            $this->api->export_filter($action_tmp, $tmp_id, $value);
                         }
                         unset($tmpObj);
                     }
                     $value = CentreonUtils::convertLineBreak($value);
                     # Host Filter
-                    if (!is_null($filter_id)) {
-                        $this->api->export_filter('HOST', $element['host_id'], $element['host_name']);
-                    }
+                    $this->api->export_filter('HOST', $element['host_id'], $element['host_name']);
                     echo $this->action . $this->delim . "setparam" . $this->delim . $element['host_name'] . $this->delim . $element['service_description'] . $this->delim . $this->getClapiActionName($parameter) . $this->delim . $value . "\n";
                 }
             }
@@ -884,25 +875,19 @@ class CentreonService extends CentreonObject {
             $cgRel = new Centreon_Object_Relation_Contact_Group_Service();
             $cgelements = $cgRel->getMergedParameters(array("cg_name", "cg_id"), array('service_description'), -1, 0, null, null, array("service_register" => $this->register, "service_id" => $element['service_id']), "AND");
             foreach ($cgelements as $cgelement) {
-                if (!is_null($filter_id)) {
-                    $this->api->export_filter('CG', $element['cg_id'], $element['cg_name']);
-                }
+                $this->api->export_filter('CG', $element['cg_id'], $element['cg_name']);
                 echo $this->action . $this->delim . "addcontactgroup" . $this->delim . $element['host_name'] . $this->delim . $cgelement['service_description'] . $this->delim . $cgelement['cg_name'] . "\n";
             }
             $contactRel = new Centreon_Object_Relation_Contact_Service();
             $celements = $contactRel->getMergedParameters(array("contact_name", "contact_id"), array('service_description'), -1, 0, null, null, array("service_register" => $this->register, "service_id" => $element['service_id']), "AND");
             foreach ($celements as $celement) {
-                if (!is_null($filter_id)) {
-                    $this->api->export_filter('CONTACT', $element['contact_id'], $element['contact_name']);
-                }
+                $this->api->export_filter('CONTACT', $element['contact_id'], $element['contact_name']);
                 echo $this->action . $this->delim . "addcontact" . $this->delim . $element['host_name'] . $this->delim . $celement['service_description'] . $this->delim . $celement['contact_name'] . "\n";
             }
             $trapRel = new Centreon_Object_Relation_Trap_Service();
             $telements = $trapRel->getMergedParameters(array("traps_name", "traps_id"), array('service_description'), -1, 0, null, null, array("service_register" => $this->register, "service.service_id" => $element['service_id']), "AND");
             foreach ($telements as $telement) {
-                if (!is_null($filter_id)) {
                 $this->api->export_filter('TRAP', $element['traps_id'], $element['traps_name']);
-            }
                 echo $this->action . $this->delim . "addtrap" . $this->delim . $element['host_name'] . $this->delim . $telement['service_description'] . $this->delim . $telement['traps_name'] . "\n";
             }
         }

--- a/www/modules/centreon-clapi/core/class/centreonServiceTemplate.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonServiceTemplate.class.php
@@ -643,9 +643,7 @@ class CentreonServiceTemplate extends CentreonObject {
                     $tmp = $this->object->getParameters($element[$param], 'service_description');
                     if (isset($tmp) && isset($tmp['service_description']) && $tmp['service_description']) {
                         $element[$param] = $tmp['service_description'];
-                        if (!is_null($filter_id)) {
-                            $this->api->export_filter('STPL', $tmp_id, $tmp['service_description']);
-                        }
+                        $this->api->export_filter('STPL', $tmp_id, $tmp['service_description']);
                     }
                     if (!$element[$param]) {
                         $element[$param] = "";
@@ -670,9 +668,7 @@ class CentreonServiceTemplate extends CentreonObject {
                         if (isset($tmp) && isset($tmp[$tmpObj->getUniqueLabelField()])) {
                             $tmp_id = $value;
                             $value = $tmp[$tmpObj->getUniqueLabelField()];
-                            if (!is_null($filter_id) && !is_null($action_tmp)) {
-                                $this->api->export_filter($action_tmp, $tmp_id, $value);
-                            }
+                            $this->api->export_filter($action_tmp, $tmp_id, $value);
                         }
                         unset($tmpObj);
                     }
@@ -710,9 +706,6 @@ class CentreonServiceTemplate extends CentreonObject {
     public function export($filter_id=null, $filter_name=null) {
         $filters = array("service_register" => $this->register);
         if (!is_null($filter_id)) {
-            if (CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name)) {
-                return 0;
-            }
             $filters['service_id'] = $filter_id;
         }
         $elements = $this->object->getList("*", -1, 0, "service_template_model_stm_id", null, $filters, "AND");
@@ -732,9 +725,7 @@ class CentreonServiceTemplate extends CentreonObject {
         }
         $elements = $cgRel->getMergedParameters(array("cg_name", "cg_id"), array('service_description'), -1, 0, null, null, $filters_cgRel, "AND");
         foreach ($elements as $element) {
-            if (!is_null($filter_id)) {
-                $this->api->export_filter('CG', $element['cg_id'], $element['cg_name']);
-            }
+            $this->api->export_filter('CG', $element['cg_id'], $element['cg_name']);
             echo $this->action . $this->delim . "addcontactgroup" . $this->delim . $element['service_description'] . $this->delim . $element['cg_name'] . "\n";
         }
 
@@ -746,9 +737,7 @@ class CentreonServiceTemplate extends CentreonObject {
         }
         $elements = $contactRel->getMergedParameters(array("contact_name", "contact_id"), array('service_description'), -1, 0, null, null, $filters_contactRel, "AND");
         foreach ($elements as $element) {
-            if (!is_null($filter_id)) {
-                $this->api->export_filter('CONTACT', $element['contact_id'], $element['contact_name']);
-            }
+            $this->api->export_filter('CONTACT', $element['contact_id'], $element['contact_name']);
             echo $this->action . $this->delim . "addcontact" . $this->delim . $element['service_description'] . $this->delim . $element['contact_name'] . "\n";
         }
 
@@ -760,9 +749,7 @@ class CentreonServiceTemplate extends CentreonObject {
         }
         $telements = $trapRel->getMergedParameters(array("traps_name", "traps_id"), array('service_description'), -1, 0, null, null, $filters_trapRel, "AND");
         foreach ($telements as $telement) {
-            if (!is_null($filter_id)) {
-                $this->api->export_filter('TRAP', $element['traps_id'], $element['traps_name']);
-            }
+            $this->api->export_filter('TRAP', $element['traps_id'], $element['traps_name']);
             echo $this->action . $this->delim . "addtrap" . $this->delim . $telement['service_description'] . $this->delim . $telement['traps_name'] . "\n";
         }
 
@@ -774,9 +761,7 @@ class CentreonServiceTemplate extends CentreonObject {
         }
         $helements = $hostRel->getMergedParameters(array("host_name", "host_id"), array('service_description'), -1, 0, null, null, $filters_hostRel, "AND");
         foreach ($helements as $helement) {
-            if (!is_null($filter_id)) {
-                $this->api->export_filter('HOST', $element['host_id'], $element['host_name']);
-            }
+            $this->api->export_filter('HOST', $element['host_id'], $element['host_name']);
             echo $this->action . $this->delim . "addhost" . $this->delim . $helement['service_description'] . $this->delim . $helement['host_name'] . "\n";
         }
     }

--- a/www/modules/centreon-clapi/core/class/centreonServiceTemplate.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonServiceTemplate.class.php
@@ -628,7 +628,7 @@ class CentreonServiceTemplate extends CentreonObject {
      * @param array $tree
      * @param Centreon_Object_Service_Extended $extendedObj 
      */
-    protected function parseTemplateTree($tree) {
+    protected function parseTemplateTree($tree, $filter_id=null) {
         $commandObj = new Centreon_Object_Command();
         $tpObj = new Centreon_Object_Timeperiod();
         $extendedObj = new Centreon_Object_Service_Extended();
@@ -638,9 +638,13 @@ class CentreonServiceTemplate extends CentreonObject {
             foreach ($this->insertParams as $param) {
                 $addStr .= $this->delim;
                 if ($param == "service_template_model_stm_id") {
+                    $tmp_id = $element[$param];
                     $tmp = $this->object->getParameters($element[$param], 'service_description');
                     if (isset($tmp) && isset($tmp['service_description']) && $tmp['service_description']) {
                         $element[$param] = $tmp['service_description'];
+                        if (!is_null($filter_id)) {
+                            $this->api->export_filter('STPL', $tmp_id, $tmp['service_description']);
+                        }
                     }
                     if (!$element[$param]) {
                         $element[$param] = "";
@@ -652,15 +656,22 @@ class CentreonServiceTemplate extends CentreonObject {
             echo $addStr;
             foreach ($element as $parameter => $value) {
                 if (!in_array($parameter, $this->exportExcludedParams) && !is_null($value) && $value != "") {
+                    $action_tmp = null;
                     if ($parameter == "timeperiod_tp_id" || $parameter == "timeperiod_tp_id2") {
+                        $action_tmp = 'TP';
                         $tmpObj = $tpObj;
                     } elseif ($parameter == "command_command_id" || $parameter == "command_command_id2") {
+                        $action_tmp = 'CMD';
                         $tmpObj = $commandObj;
                     }
                     if (isset($tmpObj)) {
                         $tmp = $tmpObj->getParameters($value, $tmpObj->getUniqueLabelField());
                         if (isset($tmp) && isset($tmp[$tmpObj->getUniqueLabelField()])) {
+                            $tmp_id = $value;
                             $value = $tmp[$tmpObj->getUniqueLabelField()];
+                            if (!is_null($filter_id) && !is_null($action_tmp)) {
+                                $this->api->export_filter($action_tmp, $tmp_id, $value);
+                            }
                         }
                         unset($tmpObj);
                     }
@@ -679,6 +690,7 @@ class CentreonServiceTemplate extends CentreonObject {
                     }
                 }
             }
+
             $macros = $macroObj->getList("*", -1, 0, null, null, array('svc_svc_id' => $element[$this->object->getPrimaryKey()]), "AND");
             foreach ($macros as $macro) {
                 echo $this->action . $this->delim . "setmacro" . $this->delim . $element['service_description'] . $this->delim . $this->stripMacro($macro['svc_macro_name']) . $this->delim . $macro['svc_macro_value'] . "\n";
@@ -694,43 +706,76 @@ class CentreonServiceTemplate extends CentreonObject {
      *
      * @return void
      */
-    public function export() {
-        $elements = $this->object->getList("*", -1, 0, "service_template_model_stm_id", null, array("service_register" => $this->register), "AND");
-        $templateTree = $this->sortTemplates($elements);
-        $macroObj = new Centreon_Object_Service_Macro_Custom();
-        $this->parseTemplateTree($templateTree);
-
+    public function export($filter_id=null, $filter_name=null) {
+        $filters = array("service_register" => $this->register);
+        if (!is_null($filter_id)) {
+            if (CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name)) {
+                return 0;
+            }
+            $filters['service_id'] = $filter_id;
+        }
+        $elements = $this->object->getList("*", -1, 0, "service_template_model_stm_id", null, $filters, "AND");
+        # No need to sort all service templates. We only export the current
+        if (is_null($filter_id)) {
+            $templateTree = $this->sortTemplates($elements);
+            $this->parseTemplateTree($templateTree);
+        } else {
+            $this->parseTemplateTree($elements, $filter_id);
+        }
+        
         // contact groups
         $cgRel = new Centreon_Object_Relation_Contact_Group_Service();
-        $elements = $cgRel->getMergedParameters(array("cg_name"), array('service_description'), -1, 0, null, null, array("service_register" => $this->register), "AND");
+        $filters_cgRel = array("service_register" => $this->register);
+        if (!is_null($filter_id)) {
+            $filters_cgRel['service_id'] = $filter_id;
+        }
+        $elements = $cgRel->getMergedParameters(array("cg_name", "cg_id"), array('service_description'), -1, 0, null, null, $filters_cgRel, "AND");
         foreach ($elements as $element) {
+            if (!is_null($filter_id)) {
+                $this->api->export_filter('CG', $element['cg_id'], $element['cg_name']);
+            }
             echo $this->action . $this->delim . "addcontactgroup" . $this->delim . $element['service_description'] . $this->delim . $element['cg_name'] . "\n";
         }
 
         // contacts
         $contactRel = new Centreon_Object_Relation_Contact_Service();
-        $elements = $contactRel->getMergedParameters(array("contact_name"), array('service_description'), -1, 0, null, null, array("service_register" => $this->register), "AND");
-        foreach ($elements as $element) {
-            echo $this->action . $this->delim . "addcontact" . $this->delim . $element['service_description'] . $this->delim . $element['contact_name'] . "\n";
+        $filters_contactRel = array("service_register" => $this->register);
+        if (!is_null($filter_id)) {
+            $filters_contactRel['service_id'] = $filter_id;
         }
-
-        // macros
-        $macros = $macroObj->getList("*", -1, 0, null, null, array('svc_svc_id' => $element[$this->object->getPrimaryKey()]), "AND");
-        foreach ($macros as $macro) {
-            echo $this->action . $this->delim . "setmacro" . $this->delim . $element['service_description'] . $this->delim . $this->stripMacro($macro['svc_macro_name']) . $this->delim . $macro['svc_macro_value'] . "\n";
+        $elements = $contactRel->getMergedParameters(array("contact_name", "contact_id"), array('service_description'), -1, 0, null, null, $filters_contactRel, "AND");
+        foreach ($elements as $element) {
+            if (!is_null($filter_id)) {
+                $this->api->export_filter('CONTACT', $element['contact_id'], $element['contact_name']);
+            }
+            echo $this->action . $this->delim . "addcontact" . $this->delim . $element['service_description'] . $this->delim . $element['contact_name'] . "\n";
         }
 
         // traps
         $trapRel = new Centreon_Object_Relation_Trap_Service();
-        $telements = $trapRel->getMergedParameters(array("traps_name"), array('service_description'), -1, 0, null, null, array("service_register" => $this->register), "AND");
+        $filters_trapRel = array("service_register" => $this->register);
+        if (!is_null($filter_id)) {
+            $filters_trapRel['traps_service_relation.service_id'] = $filter_id;
+        }
+        $telements = $trapRel->getMergedParameters(array("traps_name", "traps_id"), array('service_description'), -1, 0, null, null, $filters_trapRel, "AND");
         foreach ($telements as $telement) {
+            if (!is_null($filter_id)) {
+                $this->api->export_filter('TRAP', $element['traps_id'], $element['traps_name']);
+            }
             echo $this->action . $this->delim . "addtrap" . $this->delim . $telement['service_description'] . $this->delim . $telement['traps_name'] . "\n";
         }
 
         // hosts
         $hostRel = new Centreon_Object_Relation_Host_Service();
-        $helements = $hostRel->getMergedParameters(array("host_name"), array('service_description'), -1, 0, null, null, array("service_register" => $this->register), "AND");
+        $filters_hostRel = array("service_register" => $this->register);
+        if (!is_null($filter_id)) {
+            $filters_hostRel['service_id'] = $filter_id;
+        }
+        $helements = $hostRel->getMergedParameters(array("host_name", "host_id"), array('service_description'), -1, 0, null, null, $filters_hostRel, "AND");
         foreach ($helements as $helement) {
+            if (!is_null($filter_id)) {
+                $this->api->export_filter('HOST', $element['host_id'], $element['host_name']);
+            }
             echo $this->action . $this->delim . "addhost" . $this->delim . $helement['service_description'] . $this->delim . $helement['host_name'] . "\n";
         }
     }

--- a/www/modules/centreon-clapi/core/class/centreonTimePeriod.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonTimePeriod.class.php
@@ -296,9 +296,6 @@ class CentreonTimePeriod extends CentreonObject
 	{
         $filters = null;
         if (!is_null($filter_id)) {
-            if (CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name)) {
-                return 0;
-            }
             $filters = array('tp_id' => $filter_id);
         }
         

--- a/www/modules/centreon-clapi/core/class/centreonTimePeriod.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonTimePeriod.class.php
@@ -285,4 +285,23 @@ class CentreonTimePeriod extends CentreonObject
             $relObj->insert($sourceId, $relId);
         }
     }
+    
+    /**
+	 * Export data
+	 *
+	 * @param string $parameters
+	 * @return void
+	 */
+	public function export($filter_id=null, $filter_name=null)
+	{
+        $filters = null;
+        if (!is_null($filter_id)) {
+            if (CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name)) {
+                return 0;
+            }
+            $filters = array('tp_id' => $filter_id);
+        }
+        
+        parent::export($filters);        
+    }
 }

--- a/www/modules/centreon-clapi/core/class/centreonTrap.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonTrap.class.php
@@ -308,9 +308,6 @@ class CentreonTrap extends CentreonObject
     {
         $filters = null;
         if (!is_null($filter_id)) {
-            if (CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name)) {
-                return 0;
-            }
             $filters['traps_id'] = $filter_id;
         }
         

--- a/www/modules/centreon-clapi/core/class/centreonTrap.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonTrap.class.php
@@ -300,10 +300,17 @@ class CentreonTrap extends CentreonObject
      *
      * @return void
      */
-    public function export()
+    public function export($filter_id=null, $filter_name=null)
     {
-        $matchingObj = new Centreon_Object_Trap_Matching();
-        $elements = $this->object->getList("*", -1, 0);
+        $filters = null;
+        if (!is_null($filter_id)) {
+            if (CentreonExported::getInstance()->is_exported($this->action, $filter_id, $filter_name)) {
+                return 0;
+            }
+            $filters['traps_id'] = $filter_id;
+        }
+        
+        $elements = $this->object->getList("*", -1, 0, null, null, $filters, "AND");
         foreach ($elements as $element) {
             $addStr = $this->action.$this->delim."ADD";
             foreach ($this->insertParams as $param) {
@@ -324,6 +331,8 @@ class CentreonTrap extends CentreonObject
                     }
                 }
             }
+            
+            $matchingObj = new Centreon_Object_Trap_Matching();
             $matchingProps = $matchingObj->getList("*", -1, 0, null, null, array('trap_id' => $element['traps_id']));
             foreach ($matchingProps as $prop) {
                 echo $this->action.$this->delim.


### PR DESCRIPTION
Add the capability to filter some objects. Some examples how to use it.

Export a host and all services of the host:
```
php centreon -u admin -p centreon -e --select='HOST;srv-mssql-01' --filter-type='^(HOST|SERVICE)$'
```

Export two services (only the service):
```
php centreon -u superadmin -p centreon -e --select='SERVICE;memory' --select='SERVICE;mssql-listener' --filter-type='^SERVICE$'
```

Export all commands:
```
php centreon -u admin -p centreon -o CMD -a show | awk -F\; 'NR > 2 { print "--select=\"CMD;" $2 "\"" }' | xargs --verbose php centreon -u admin -p centreon -e
```