### PR TITLE
Allow ar_id to be imported in a contact

### DIFF
--- a/www/modules/centreon-clapi/core/class/centreonContact.class.php
+++ b/www/modules/centreon-clapi/core/class/centreonContact.class.php
@@ -305,7 +305,9 @@ class CentreonContact extends CentreonObject {
                         }
                     }
                 }
-                $params[1] = "contact_" . $params[1];
+		if ($params[1] != "ar_id") {                
+			$params[1] = "contact_" . $params[1];
+		}
             }
 
             if ($regularParam == true) {


### PR DESCRIPTION
When exporting contact configuration, if an user has a ar_id parameter, the import fails.

Steps to reproduce : 
- export the whole configuration to a file with centreon-clapi
- just keep in the exported file a contact configuration with an ar_id like : 
  CONTACT;setparam;My-USER;ar_id;1

If you import such configuration, the import fails with error : 
Line 7 : SQLSTATE[42S22]: Column not found: 1054 Unknown column 'contact_ar_id' in 'field list'
